### PR TITLE
[ISSUE-#17] 대기열에 있는 쿠폰 발행 요청을 처리하는 스케줄러 로직 구현

### DIFF
--- a/coupon-consumer/src/main/java/com/commerce/couponconsumer/listener/CouponIssueListener.java
+++ b/coupon-consumer/src/main/java/com/commerce/couponconsumer/listener/CouponIssueListener.java
@@ -1,0 +1,57 @@
+package com.commerce.couponconsumer.listener;
+
+import com.commerce.couponcore.exception.CouponIssueException;
+import com.commerce.couponcore.exception.ErrorCode;
+import com.commerce.couponcore.repository.redis.RedisRepository;
+import com.commerce.couponcore.repository.redis.dto.CouponIssueRequest;
+import com.commerce.couponcore.service.CouponIssueService;
+import com.commerce.couponcore.util.CouponRedisUtils;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@EnableScheduling
+@RequiredArgsConstructor
+public class CouponIssueListener {
+
+    private final CouponIssueService couponIssueService;
+    private final RedisRepository redisRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final String issueRequestQueueKey = CouponRedisUtils.getCouponIssueRequestQueueKey();
+
+    @Scheduled(fixedDelay = 1000)
+    public void issue() {
+        var queueSize = getCouponIssueRequestSize();
+        while (queueSize > 0) {
+            var target = getIssueTarget();
+            couponIssueService.issue(target.couponId(), target.userId());
+            log.info("쿠폰 발행 완료. coupon id : {}, user id : {}", target.couponId(), target.userId());
+            removeIssuedTarget();
+            queueSize--;
+        }
+    }
+
+    private CouponIssueRequest getIssueTarget() {
+        CouponIssueRequest req;
+        try {
+            req = objectMapper.readValue(redisRepository.listIndex(issueRequestQueueKey, 0), CouponIssueRequest.class);
+        } catch (JsonProcessingException exception) {
+            throw new CouponIssueException(ErrorCode.FAILED_PULL_COUPON_ISSUE_REQUEST);
+        }
+        return req;
+    }
+
+    private Long getCouponIssueRequestSize() {
+        return redisRepository.listSize(issueRequestQueueKey);
+    }
+
+    private void removeIssuedTarget() {
+        redisRepository.lPop(issueRequestQueueKey);
+    }
+}

--- a/coupon-consumer/src/main/java/com/commerce/couponconsumer/listener/CouponIssueListener.java
+++ b/coupon-consumer/src/main/java/com/commerce/couponconsumer/listener/CouponIssueListener.java
@@ -30,10 +30,11 @@ public class CouponIssueListener {
         var queueSize = getCouponIssueRequestSize();
         while (queueSize > 0) {
             var target = getIssueTarget();
-            couponIssueService.issue(target.couponId(), target.userId());
-            log.info("쿠폰 발행 완료. coupon id : {}, user id : {}", target.couponId(), target.userId());
             removeIssuedTarget();
             queueSize--;
+            log.info("쿠폰 발행 시작 coupon id : {}, user id : {}", target.couponId(), target.userId());
+            couponIssueService.issue(target.couponId(), target.userId());
+            log.info("쿠폰 발행 완료. coupon id : {}, user id : {}", target.couponId(), target.userId());
         }
     }
 

--- a/coupon-core/src/main/java/com/commerce/couponcore/exception/ErrorCode.java
+++ b/coupon-core/src/main/java/com/commerce/couponcore/exception/ErrorCode.java
@@ -17,7 +17,8 @@ public enum ErrorCode {
     COUPON_DUPLICATE(HttpStatus.CONFLICT, "001", "Coupon already issued"),
     // 500 INTERNAL_SERVER_ERROR
     LOCK_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "001", "Lock failed"),
-    FAIL_COUPON_ISSUE_REQUEST(HttpStatus.INTERNAL_SERVER_ERROR, "002", "Coupon issue request failed.");
+    FAIL_COUPON_ISSUE_REQUEST(HttpStatus.INTERNAL_SERVER_ERROR, "002", "Coupon issue request failed."),
+    FAILED_PULL_COUPON_ISSUE_REQUEST(HttpStatus.INTERNAL_SERVER_ERROR, "003", "Coupon issue request pulling failed.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/coupon-core/src/main/java/com/commerce/couponcore/repository/redis/RedisRepository.java
+++ b/coupon-core/src/main/java/com/commerce/couponcore/repository/redis/RedisRepository.java
@@ -21,4 +21,16 @@ public class RedisRepository {
     public void rPush(String key, String value) {
         redisTemplate.opsForList().rightPush(key, value);
     }
+
+    public Long listSize(String key) {
+        return redisTemplate.opsForList().size(key);
+    }
+
+    public String listIndex(String key, int index) {
+        return redisTemplate.opsForList().index(key, index);
+    }
+
+    public void lPop(String key) {
+        redisTemplate.opsForList().leftPop(key);
+    }
 }

--- a/coupon-core/src/main/java/com/commerce/couponcore/repository/redis/RedisRepository.java
+++ b/coupon-core/src/main/java/com/commerce/couponcore/repository/redis/RedisRepository.java
@@ -33,4 +33,8 @@ public class RedisRepository {
     public void lPop(String key) {
         redisTemplate.opsForList().leftPop(key);
     }
+
+    public Long setSize(String key) {
+        return redisTemplate.opsForSet().size(key);
+    }
 }

--- a/coupon-core/src/main/java/com/commerce/couponcore/service/CouponIssueRedisService.java
+++ b/coupon-core/src/main/java/com/commerce/couponcore/service/CouponIssueRedisService.java
@@ -19,10 +19,18 @@ public class CouponIssueRedisService {
         if (!availableUserIssueQuantity(coupon.getId(), userId)) {
             throw new CouponIssueException(ErrorCode.COUPON_ALREADY_ISSUED);
         }
+        if (!availableCouponTotalQuantity(coupon.getId(), coupon.getTotalQuantity())) {
+            throw new CouponIssueException(ErrorCode.COUPON_ISSUE_INVALID_QUANTITY);
+        }
     }
 
     public boolean availableUserIssueQuantity(long couponId, long userId) {
         String key = CouponRedisUtils.getCouponIssueRequestKey(couponId);
         return !redisRepository.sIsMember(key, String.valueOf(userId));
+    }
+
+    public boolean availableCouponTotalQuantity(long couponId, long totalQuantity) {
+        String key = CouponRedisUtils.getCouponIssueRequestKey(couponId);
+        return redisRepository.setSize(key) < totalQuantity;
     }
 }

--- a/coupon-core/src/main/java/com/commerce/couponcore/service/CouponIssueService.java
+++ b/coupon-core/src/main/java/com/commerce/couponcore/service/CouponIssueService.java
@@ -8,9 +8,11 @@ import com.commerce.couponcore.repository.CouponIssueJpaRepository;
 import com.commerce.couponcore.repository.CouponIssueRepository;
 import com.commerce.couponcore.repository.CouponJpaRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class CouponIssueService {
@@ -21,6 +23,7 @@ public class CouponIssueService {
 
     @Transactional
     public void issue(long couponId, long userId) {
+        log.info("쿠폰 발행 시작 coupon id : {}, user id : {}", couponId, userId);
         Coupon coupon = findCoupon(couponId);
         coupon.issue();
         saveCouponIssue(couponId, userId);
@@ -47,7 +50,7 @@ public class CouponIssueService {
     public void checkAlreadyIssued(long couponId, long userId) {
         CouponIssue couponIssue = couponIssueRepository.findFirstCouponIssue(couponId, userId);
         if (couponIssue != null) {
-            throw new CouponIssueException(ErrorCode.COUPON_DUPLICATE);
+            throw new CouponIssueException(ErrorCode.COUPON_ALREADY_ISSUED);
         }
     }
 

--- a/coupon-core/src/main/java/com/commerce/couponcore/service/CouponIssueService.java
+++ b/coupon-core/src/main/java/com/commerce/couponcore/service/CouponIssueService.java
@@ -23,7 +23,6 @@ public class CouponIssueService {
 
     @Transactional
     public void issue(long couponId, long userId) {
-        log.info("쿠폰 발행 시작 coupon id : {}, user id : {}", couponId, userId);
         Coupon coupon = findCoupon(couponId);
         coupon.issue();
         saveCouponIssue(couponId, userId);


### PR DESCRIPTION
- [ISSUE-#23] Redis에 저장되는 쿠폰 발행 요청의 최대 갯수는 Coupon의 Total Quantity로 제한하기
- [ISSUE-#25] 대기열에 있는 요청을 처리하다가 예외가 발생할 경우, 거기서 병목이 일어나는 문제 해결
     - HOW : 쿠폰 발행 로직 시작 전, redis 대기열에서 left pop 처리 + 쿠폰 발행 시작 전과 완료 후에 로그로 coupon id , user id 를 남김.