### PR TITLE
[ISSUE-#27] lua script 작성으로 분산락 구현 없이 필요한 쿼리를 redis에서 직접 실행하도록 스크립트 작성

### DIFF
--- a/coupon-api/src/main/java/com/commerce/couponapi/controller/CouponIssueController.java
+++ b/coupon-api/src/main/java/com/commerce/couponapi/controller/CouponIssueController.java
@@ -14,21 +14,27 @@ public class CouponIssueController {
 
     private final CouponIssueRequestService couponIssueRequestService;
 
-    @PostMapping("/v1/issue/lock/redis")
+    @PostMapping("/v1/issue/redis-lock")
     public CouponIssueResponseDto issueRedis(@RequestBody CouponIssueRequestDto requestDto) {
         couponIssueRequestService.issueRequestWithRedisLock(requestDto);
         return new CouponIssueResponseDto(true, null);
     }
 
-    @PostMapping("/v1/issue/lock/mysql")
+    @PostMapping("/v1/issue/mysql-lock")
     public CouponIssueResponseDto issueMySQL(@RequestBody CouponIssueRequestDto requestDto) {
         couponIssueRequestService.issueRequestWithMySQLLock(requestDto);
         return new CouponIssueResponseDto(true, null);
     }
 
     @PostMapping("/v1/issue-async")
-    public CouponIssueResponseDto issueAsync(@RequestBody CouponIssueRequestDto requestDto) {
-        couponIssueRequestService.asyncIssueRequest(requestDto);
+    public CouponIssueResponseDto issueAsyncWithRedisLock(@RequestBody CouponIssueRequestDto requestDto) {
+        couponIssueRequestService.asyncIssueRequestWithRedisLock(requestDto);
+        return new CouponIssueResponseDto(true, null);
+    }
+
+    @PostMapping("/v2/issue-async")
+    public CouponIssueResponseDto issueAsyncWithScript(@RequestBody CouponIssueRequestDto requestDto) {
+        couponIssueRequestService.asyncIssueRequestWithScript(requestDto);
         return new CouponIssueResponseDto(true, null);
     }
 }

--- a/coupon-api/src/main/java/com/commerce/couponapi/service/CouponIssueRequestService.java
+++ b/coupon-api/src/main/java/com/commerce/couponapi/service/CouponIssueRequestService.java
@@ -19,9 +19,9 @@ public class CouponIssueRequestService {
     private final DistributeLockExecutor distributeLockExecutor;
 
     public void issueRequestWithRedisLock(CouponIssueRequestDto requestDto) {
-        distributeLockExecutor.execute(RedisLockUtils.getCouponLockName(requestDto.couponId()) + requestDto.couponId(),
+        distributeLockExecutor.execute(RedisLockUtils.getCouponLockName(requestDto.couponId()),
                 10000, 10000,
-                () -> couponIssueService.issue(requestDto.couponId(), requestDto.userId()));
+                () -> couponIssueService.issueWithRedisLock(requestDto.couponId(), requestDto.userId()));
         log.info("쿠폰 발급 완료. coupon id : {}, user id : {}", requestDto.couponId(), requestDto.userId());
     }
 
@@ -30,7 +30,11 @@ public class CouponIssueRequestService {
         log.info("쿠폰 발급 완료. coupon id : {}, user id : {}", requestDto.couponId(), requestDto.userId());
     }
 
-    public void asyncIssueRequest(CouponIssueRequestDto requestDto) {
-        asyncCouponIssueService.issue(requestDto.couponId(), requestDto.userId());
+    public void asyncIssueRequestWithRedisLock(CouponIssueRequestDto requestDto) {
+        asyncCouponIssueService.issueWithRedisLock(requestDto.couponId(), requestDto.userId());
+    }
+
+    public void asyncIssueRequestWithScript(CouponIssueRequestDto requestDto) {
+        asyncCouponIssueService.issueWithScript(requestDto.couponId(), requestDto.userId());
     }
 }

--- a/coupon-consumer/src/main/java/com/commerce/couponconsumer/listener/CouponIssueListener.java
+++ b/coupon-consumer/src/main/java/com/commerce/couponconsumer/listener/CouponIssueListener.java
@@ -33,7 +33,7 @@ public class CouponIssueListener {
             removeIssuedTarget();
             queueSize--;
             log.info("쿠폰 발행 시작 coupon id : {}, user id : {}", target.couponId(), target.userId());
-            couponIssueService.issue(target.couponId(), target.userId());
+            couponIssueService.issueFromQueue(target.couponId(), target.userId());
             log.info("쿠폰 발행 완료. coupon id : {}, user id : {}", target.couponId(), target.userId());
         }
     }

--- a/coupon-core/src/main/java/com/commerce/couponcore/CouponCoreConfiguration.java
+++ b/coupon-core/src/main/java/com/commerce/couponcore/CouponCoreConfiguration.java
@@ -1,9 +1,11 @@
 package com.commerce.couponcore;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableCaching
 @EnableJpaAuditing
 @ComponentScan
 @EnableAutoConfiguration

--- a/coupon-core/src/main/java/com/commerce/couponcore/component/CouponEventListener.java
+++ b/coupon-core/src/main/java/com/commerce/couponcore/component/CouponEventListener.java
@@ -1,0 +1,20 @@
+package com.commerce.couponcore.component;
+
+import com.commerce.couponcore.event.CouponIssueCompleteEvent;
+import com.commerce.couponcore.service.CouponCacheService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class CouponEventListener {
+
+    private final CouponCacheService couponCacheService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    void issueComplete(CouponIssueCompleteEvent event) {
+        couponCacheService.putCouponCache(event.couponId());
+    }
+}

--- a/coupon-core/src/main/java/com/commerce/couponcore/config/CacheConfiguration.java
+++ b/coupon-core/src/main/java/com/commerce/couponcore/config/CacheConfiguration.java
@@ -1,0 +1,31 @@
+package com.commerce.couponcore.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@RequiredArgsConstructor
+public class CacheConfiguration {
+
+    private final RedisConnectionFactory redisConnectionFactory;
+
+    @Bean
+    public RedisCacheManager cacheManager() {
+        var cacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(Duration.ofMinutes(30));
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(cacheConfiguration)
+                .build();
+    }
+}

--- a/coupon-core/src/main/java/com/commerce/couponcore/event/CouponIssueCompleteEvent.java
+++ b/coupon-core/src/main/java/com/commerce/couponcore/event/CouponIssueCompleteEvent.java
@@ -1,0 +1,4 @@
+package com.commerce.couponcore.event;
+
+public record CouponIssueCompleteEvent(long couponId) {
+}

--- a/coupon-core/src/main/java/com/commerce/couponcore/repository/redis/RedisRepository.java
+++ b/coupon-core/src/main/java/com/commerce/couponcore/repository/redis/RedisRepository.java
@@ -1,14 +1,27 @@
 package com.commerce.couponcore.repository.redis;
 
+import com.commerce.couponcore.exception.CouponIssueException;
+import com.commerce.couponcore.exception.ErrorCode;
+import com.commerce.couponcore.repository.redis.dto.CouponIssueRequest;
+import com.commerce.couponcore.repository.redis.dto.CouponIssueRequestCode;
+import com.commerce.couponcore.util.CouponRedisUtils;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
 public class RedisRepository {
 
     private final RedisTemplate<String, String> redisTemplate;
+    private final RedisScript<String> issueScript = issueRequestScript();
+    private final String issueRequestQueueKey = CouponRedisUtils.getCouponIssueRequestQueueKey();
+    private final ObjectMapper objectMapper;
 
     public boolean sIsMember(String key, String value) {
         return redisTemplate.opsForSet().isMember(key, value);
@@ -36,5 +49,39 @@ public class RedisRepository {
 
     public Long setSize(String key) {
         return redisTemplate.opsForSet().size(key);
+    }
+
+    public void issueRequest(long couponId, long userId, int totalIssueQuantity) {
+        String issueRequestKey = CouponRedisUtils.getCouponIssueRequestKey(couponId);
+        CouponIssueRequest couponIssueRequest = new CouponIssueRequest(couponId, userId);
+        try {
+            String code = redisTemplate.execute(
+                    issueScript,
+                    List.of(issueRequestKey, issueRequestQueueKey),
+                    String.valueOf(userId),
+                    String.valueOf(totalIssueQuantity),
+                    objectMapper.writeValueAsString(couponIssueRequest)
+            );
+            CouponIssueRequestCode.checkRequestResult(CouponIssueRequestCode.find(code));
+        } catch (JsonProcessingException e) {
+            throw new CouponIssueException(ErrorCode.FAIL_COUPON_ISSUE_REQUEST);
+        }
+    }
+
+    private RedisScript<String> issueRequestScript() {
+        String script = """
+                if redis.call('SISMEMBER', KEYS[1], ARGV[1]) == 1 then
+                    return '2'
+                end
+                                
+                if tonumber(ARGV[2]) > redis.call('SCARD', KEYS[1]) then
+                    redis.call('SADD', KEYS[1], ARGV[1])
+                    redis.call('RPUSH', KEYS[2], ARGV[3])
+                    return '1'
+                end
+                                
+                return '3'
+                """;
+        return RedisScript.of(script, String.class);
     }
 }

--- a/coupon-core/src/main/java/com/commerce/couponcore/repository/redis/dto/CouponIssueRequestCode.java
+++ b/coupon-core/src/main/java/com/commerce/couponcore/repository/redis/dto/CouponIssueRequestCode.java
@@ -1,0 +1,31 @@
+package com.commerce.couponcore.repository.redis.dto;
+
+import com.commerce.couponcore.exception.CouponIssueException;
+import com.commerce.couponcore.exception.ErrorCode;
+
+public enum CouponIssueRequestCode {
+    SUCCESS(1),
+    DUPLICATED_COUPON_ISSUE(2),
+    INVALID_COUPON_ISSUE_QUANTITY(3);
+
+
+    CouponIssueRequestCode(int code) {
+    }
+
+    public static CouponIssueRequestCode find(String code) {
+        int codeValue = Integer.parseInt(code);
+        if (codeValue == 1) return SUCCESS;
+        if (codeValue == 2) return DUPLICATED_COUPON_ISSUE;
+        if (codeValue == 3) return INVALID_COUPON_ISSUE_QUANTITY;
+        throw new IllegalArgumentException("CODE NUMBER NOT DEFINED : %s".formatted(code));
+    }
+
+    public static void checkRequestResult(CouponIssueRequestCode code) {
+        if (code == INVALID_COUPON_ISSUE_QUANTITY) {
+            throw new CouponIssueException(ErrorCode.COUPON_ISSUE_INVALID_QUANTITY);
+        }
+        if (code == DUPLICATED_COUPON_ISSUE) {
+            throw new CouponIssueException(ErrorCode.COUPON_ALREADY_ISSUED);
+        }
+    }
+}

--- a/coupon-core/src/main/java/com/commerce/couponcore/repository/redis/dto/CouponRedisEntity.java
+++ b/coupon-core/src/main/java/com/commerce/couponcore/repository/redis/dto/CouponRedisEntity.java
@@ -1,0 +1,49 @@
+package com.commerce.couponcore.repository.redis.dto;
+
+import com.commerce.couponcore.exception.CouponIssueException;
+import com.commerce.couponcore.exception.ErrorCode;
+import com.commerce.couponcore.model.Coupon;
+import com.commerce.couponcore.model.CouponType;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+
+import java.time.LocalDateTime;
+
+public record CouponRedisEntity(
+        Long id,
+        CouponType couponType,
+        Integer totalQuantity,
+        boolean availableIssue,
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+        @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+        LocalDateTime dateIssueStart,
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+        @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+        LocalDateTime dateIssueEnd
+) {
+    public CouponRedisEntity(Coupon coupon) {
+        this(coupon.getId(),
+                coupon.getCouponType(),
+                coupon.getTotalQuantity(),
+                coupon.availableIssueQuantity(),
+                coupon.getDateIssueStart(),
+                coupon.getDateIssueEnd()
+        );
+    }
+
+    private boolean availableIssueDate() {
+        LocalDateTime now = LocalDateTime.now();
+        return dateIssueStart.isBefore(now) && dateIssueEnd.isAfter(now);
+    }
+
+    public void checkIssuable() {
+        if (!availableIssueDate()) {
+            throw new CouponIssueException(ErrorCode.COUPON_ISSUE_INVALID_DATE);
+        }
+        if (!availableIssue) {
+            throw new CouponIssueException(ErrorCode.COUPON_ISSUE_INVALID_QUANTITY);
+        }
+    }
+}

--- a/coupon-core/src/main/java/com/commerce/couponcore/service/CouponCacheService.java
+++ b/coupon-core/src/main/java/com/commerce/couponcore/service/CouponCacheService.java
@@ -1,0 +1,26 @@
+package com.commerce.couponcore.service;
+
+import com.commerce.couponcore.model.Coupon;
+import com.commerce.couponcore.repository.redis.dto.CouponRedisEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CouponCacheService {
+
+    private final CouponIssueService couponIssueService;
+
+    @Cacheable(cacheNames = "coupon", key = "#p0")
+    public CouponRedisEntity getCouponCache(long couponId) {
+        Coupon coupon = couponIssueService.findCoupon(couponId);
+        return new CouponRedisEntity(coupon);
+    }
+
+    @CachePut(cacheNames = "coupon", key = "#p0")
+    public CouponRedisEntity putCouponCache(long couponId) {
+        return getCouponCache(couponId);
+    }
+}

--- a/coupon-core/src/main/java/com/commerce/couponcore/service/CouponIssueRedisService.java
+++ b/coupon-core/src/main/java/com/commerce/couponcore/service/CouponIssueRedisService.java
@@ -2,8 +2,8 @@ package com.commerce.couponcore.service;
 
 import com.commerce.couponcore.exception.CouponIssueException;
 import com.commerce.couponcore.exception.ErrorCode;
-import com.commerce.couponcore.model.Coupon;
 import com.commerce.couponcore.repository.redis.RedisRepository;
+import com.commerce.couponcore.repository.redis.dto.CouponRedisEntity;
 import com.commerce.couponcore.util.CouponRedisUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,11 +15,11 @@ public class CouponIssueRedisService {
     private final RedisRepository redisRepository;
 
 
-    public void checkIssuable(Coupon coupon, Long userId) {
-        if (!availableUserIssueQuantity(coupon.getId(), userId)) {
+    public void checkIssuable(CouponRedisEntity coupon, Long userId) {
+        if (!availableUserIssueQuantity(coupon.id(), userId)) {
             throw new CouponIssueException(ErrorCode.COUPON_ALREADY_ISSUED);
         }
-        if (!availableCouponTotalQuantity(coupon.getId(), coupon.getTotalQuantity())) {
+        if (!availableCouponTotalQuantity(coupon.id(), coupon.totalQuantity())) {
             throw new CouponIssueException(ErrorCode.COUPON_ISSUE_INVALID_QUANTITY);
         }
     }

--- a/coupon-core/src/test/java/com/commerce/couponcore/service/CouponIssueServiceTest.java
+++ b/coupon-core/src/test/java/com/commerce/couponcore/service/CouponIssueServiceTest.java
@@ -82,7 +82,7 @@ class CouponIssueServiceTest extends TestConfig {
         Coupon saved = couponJpaRepository.save(coupon);
 
         // when
-        sut.issue(coupon.getId(), userId);
+        sut.issueWithRedisLock(coupon.getId(), userId);
 
         // then
         Assertions.assertEquals(saved.getIssuedQuantity(), 1);
@@ -97,7 +97,7 @@ class CouponIssueServiceTest extends TestConfig {
         long couponId = 1L;
 
         // when & then
-        CouponIssueException exception = assertThrows(CouponIssueException.class, () -> sut.issue(couponId, userId));
+        CouponIssueException exception = assertThrows(CouponIssueException.class, () -> sut.issueWithRedisLock(couponId, userId));
         Assertions.assertEquals(exception.getErrorCode(), ErrorCode.COUPON_NOT_EXIST);
     }
 
@@ -117,7 +117,7 @@ class CouponIssueServiceTest extends TestConfig {
         Coupon saved = couponJpaRepository.save(coupon);
 
         // when & then
-        CouponIssueException exception = assertThrows(CouponIssueException.class, () -> sut.issue(saved.getId(), userId));
+        CouponIssueException exception = assertThrows(CouponIssueException.class, () -> sut.issueWithRedisLock(saved.getId(), userId));
         Assertions.assertEquals(exception.getErrorCode(), ErrorCode.COUPON_ISSUE_INVALID_DATE);
     }
 
@@ -137,7 +137,7 @@ class CouponIssueServiceTest extends TestConfig {
         Coupon saved = couponJpaRepository.save(coupon);
 
         // when & then
-        CouponIssueException exception = assertThrows(CouponIssueException.class, () -> sut.issue(saved.getId(), userId));
+        CouponIssueException exception = assertThrows(CouponIssueException.class, () -> sut.issueWithRedisLock(saved.getId(), userId));
         Assertions.assertEquals(exception.getErrorCode(), ErrorCode.COUPON_ISSUE_INVALID_QUANTITY);
     }
 }


### PR DESCRIPTION
- [ISSUE-#27] lua script 작성으로 분산락 구현 없이 필요한 쿼리를 redis에서 직접 실행하도록 스크립트 작성
- [ISSUE-#19] 대기열에 있는 쿠폰 발급 요청 처리 시, Event를 publish하여, redis에 저장된 캐시값도 업데이트되도록 로직 추가